### PR TITLE
Group-based scopes Avg, Min, Max should extend ScopeGroup, closes #3

### DIFF
--- a/src/exprlib/contexts/scope/Avg.php
+++ b/src/exprlib/contexts/scope/Avg.php
@@ -2,10 +2,10 @@
 
 namespace exprlib\contexts\scope;
 
-use exprlib\contexts\Scope;
+use exprlib\contexts\ScopeGroup;
 use exprlib\exceptions\ParsingException;
 
-class Avg extends Scope
+class Avg extends ScopeGroup
 {
     public function evaluate()
     {

--- a/src/exprlib/contexts/scope/Max.php
+++ b/src/exprlib/contexts/scope/Max.php
@@ -2,10 +2,10 @@
 
 namespace exprlib\contexts\scope;
 
-use exprlib\contexts\Scope;
+use exprlib\contexts\ScopeGroup;
 use exprlib\exceptions\ParsingException;
 
-class Max extends Scope
+class Max extends ScopeGroup
 {
     public function evaluate()
     {

--- a/src/exprlib/contexts/scope/Min.php
+++ b/src/exprlib/contexts/scope/Min.php
@@ -2,10 +2,10 @@
 
 namespace exprlib\contexts\scope;
 
-use exprlib\contexts\Scope;
+use exprlib\contexts\ScopeGroup;
 use exprlib\exceptions\ParsingException;
 
-class Min extends Scope
+class Min extends ScopeGroup
 {
     public function evaluate()
     {


### PR DESCRIPTION
Changing the base class for these three scopes allows equations like this to work:

```
avg(4, 5, 6) + avg(9, 10, 111)
```
